### PR TITLE
Point flannel installation to `master` for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sudo kubeadm init --token-ttl=0 --pod-network-cidr=10.244.0.0/16 --apiserver-adv
 mkdir -p $HOME/.kube
 sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/c5d10c8/Documentation/kube-flannel.yml
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 kubectl patch daemonset kube-flannel-ds-arm \
   --namespace=kube-system \
   --patch='{"spec":{"template":{"spec":{"tolerations":[{"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect":


### PR DESCRIPTION
Yes, while this is risky, the "current" version of k8s is a moving target,
so we'll need to use the latest and greatest flannel configuration when
setting things up